### PR TITLE
Add stdint.h include to ez80f92.h

### DIFF
--- a/release/include/ez80f92.h
+++ b/release/include/ez80f92.h
@@ -1,6 +1,8 @@
 #ifndef EZ80F92_H
 #define EZ80F92_H
 
+#include <stdint.h>
+
 #define IO(addr) (*((volatile uint8_t __attribute__((address_space(3)))*)(addr)))
 
 #define TMR0_CTL        0x80


### PR DESCRIPTION
Header uses uint8_t without including the appropriate standard header. Makes the header able to be included stand-alone, otherwise apps have to do

```cpp
#include <stdint.h>
#include <ez80f92.h>
```