### PR TITLE
fixed ldvrmu/ldivu/lremu and C ldiv

### DIFF
--- a/src/lib/libc/ldiv.src
+++ b/src/lib/libc/ldiv.src
@@ -2,8 +2,11 @@
 
 	.section	.text
 	.global	_ldiv
-_ldiv:
 
+; REMEMBER to keep ldivu.src, lremu.src, and ldiv.src in sync with this choice
+.if 0
+
+_ldiv:
 	pop	hl
 	pop	iy
 	pop	de
@@ -24,7 +27,7 @@ _ldiv:
 	bit	7, e
 	call	__ldivs_lrems_common
 
-	call	__ldvrmu
+	call	__ldivu_lremu_common
 
 	exx
 	ld	e, a
@@ -45,12 +48,74 @@ _ldiv:
 	push	de
 	push	de
 	bit	2, c
-	jr	z, .ei_skip
+	jr	z, .L.ei_skip
 	ei
-.ei_skip:
+.L.ei_skip:
 	jp	(hl)
 
+	.extern	__ldivu_lremu_common
+
+.else
+
+_ldiv:
+	pop	hl		; return address
+	pop	iy		; ldiv_t pointer
+	pop	de		; [ 0:23] numerator
+	pop	bc		; [24:31] numerator
+	ld	a, c
+	pop	bc		; [ 0:23] denominator
+	ex	(sp), hl	; [24:31] denominator
+	ex	de, hl
+
+	push	ix		; preserve IX since __ldvrmu destroys it
+	ld	d, a
+	xor	a, e
+	push	af		; quotient sign
+
+	ld	a, e
+	ld	e, d
+	push	de		; remainder sign
+
+	bit	7, e
+	call	__ldivs_lrems_common
+
+	push	iy		; preserve IY since __ldvrmu destroys it
+	; E:UHL = numerator
+	; A:UBC = denominator
+	call	__ldvrmu
+	; E:UIX = quotient
+	; A:UHL = remainder
+	pop	iy		; restore IY = ldiv_t pointer
+
+	ld	d, e		; preserve E
+	ld	e, a
+	pop	af		; remainder sign
+
+	; E:UHL = remainder
+	call	m, __lneg
+	ld	(iy + 4), hl
+	ld	(iy + 7), e
+
+	pop	af		; quotient sign
+
+	lea	hl, ix + 0
+	pop	ix		; restore IX
+	ld	e, d		; restore E
+	; E:UHL = quotient
+	call	m, __lneg
+	ld	(iy), hl
+	ld	(iy + 3), e
+
+	ex	(sp), hl	; HL = return address
+	push	de
+	push	de
+	push	de
+	push	de
+	jp	(hl)
+
+	.extern	__ldvrmu
+
+.endif
 
 	.extern	__ldivs_lrems_common
-	.extern	__ldvrmu
 	.extern	__lneg

--- a/src/lib/libclang/ldivs.src
+++ b/src/lib/libclang/ldivs.src
@@ -20,9 +20,9 @@ __ldivs:
 
 	rlca
 	rrca
-	jr	nz, .pos_dividend_skip
+	jr	nz, .L.pos_dividend_skip
 	ccf
-.pos_dividend_skip:
+.L.pos_dividend_skip:
 
 	ret	c
 	jp	__lneg
@@ -30,4 +30,3 @@ __ldivs:
 	.extern	__ldivs_lrems_common
 	.extern	__ldivu
 	.extern	__lneg
-

--- a/src/lib/libclang/ldivu.src
+++ b/src/lib/libclang/ldivu.src
@@ -3,14 +3,15 @@
 	.section	.text
 	.global	__ldivu
 
+; REMEMBER to keep ldivu.src, lremu.src, and ldiv.src in sync with this choice
+.if 0
+
 __ldivu:
 ; I: EUHL=dividend, AUBC=divisor
 ; O: euhl=EUHL/AUBC
-
-.if 1
 	push	bc
 
-	call	__ldvrmu
+	call	__ldivu_lremu_common
 
 	ld	a, b
 	pop	bc
@@ -19,7 +20,13 @@ __ldivu:
 	ei
 	ret
 
+	.extern	__ldivu_lremu_common
+
 .else
+
+__ldivu:
+; I: EUHL=dividend, AUBC=divisor
+; O: euhl=EUHL/AUBC
 	push	ix
 	push	iy
 
@@ -30,6 +37,7 @@ __ldivu:
 	pop	hl
 
 	ret
-.endif
 
 	.extern	__ldvrmu
+
+.endif

--- a/src/lib/libclang/ldivu_lremu_common.src
+++ b/src/lib/libclang/ldivu_lremu_common.src
@@ -1,0 +1,85 @@
+	.assume	adl=1
+
+	.section	.text
+
+	.global	__ldivu_lremu_common
+
+;;; struct u32div_t {
+;;;     uint32_t rem;
+;;;     uint32_t quot;
+;;; };
+;;; u32div_t _ldivu_lremu_common(uint32_t dividend, uint32_t divisor) {
+
+__ldivu_lremu_common:
+; Similar to __ldvrmu but faster and with a different calling convention.
+; Note: Uses shadow registers and disables interrupts.
+; I: EUHL=dividend, AUBC=divisor
+; O: a[uhl']=EUHL%AUBC, bcu=0, b=A, c=?, euhl=EUHL/AUBC, eubc'=AUBC, zf=!IEF2
+
+;;;     u32div_t result;
+;;;     result.quot = dividend;
+					; euhl : result.quot
+
+	push	bc
+
+	ld	c, a			; c = A
+	ld	a, i			; a = I
+					; pf = IEF2
+	di
+
+	ld	a, c			; a = A
+	exx
+	pop	bc
+	ld	e, a			; eubc' : divisor
+
+	push	af
+
+;;;     result.rem = 0;
+	xor	a, a
+	sbc	hl, hl			; auhl' : result.rem
+
+;;;     int i = 32;
+	exx
+	ld	b, 32			; b : i
+
+;;;     do {
+.L.c.loop:
+
+;;;         bool dividendBit = result.quot >> 31;
+;;;         result.quot <<= 1;
+	add	hl, hl
+	rl	e
+;;;         result.rem = (result.rem << 1) + dividendBit;
+	exx
+	adc	hl, hl
+	adc	a, a
+
+;;;         bool quotBit = result.rem >= divisor;
+;;;         result.rem -= divisor;
+	sbc	hl, bc
+	sbc	a, e
+
+;;;         if (!quotBit) {
+	jr	nc, .L.c.restore_skip
+;;;             result.rem += divisor;
+	add	hl, bc
+	adc	a, e
+;;;         }
+.L.c.restore_skip:
+
+;;;         if (quotBit) {
+	exx
+	jr	c, .L.c.skip
+;;;             result.quot++;
+	inc	l
+;;;         }
+.L.c.skip:
+
+;;;     } while (--i != 0);
+	djnz	.L.c.loop
+
+;;;     return result;
+	pop	bc
+	bit	2, c
+	ret
+;;; }

--- a/src/lib/libclang/ldvrmu.src
+++ b/src/lib/libclang/ldvrmu.src
@@ -1,91 +1,12 @@
 	.assume	adl=1
 
 	.section	.text
-;;; struct u32div_t {
-;;;     uint32_t rem;
-;;;     uint32_t quot;
-;;; };
-;;; u32div_t _ldvrmu(uint32_t dividend, uint32_t divisor) {
+
 	.global	__ldvrmu
 
 __ldvrmu:
-.if 0
-; I: EUHL=dividend, AUBC=divisor
-; O: a[uhl']=EUHL%AUBC, bcu=0, b=A, c=?, euhl=EUHL/AUBC, eubc'=AUBC, zf=!IEF2
-
-;;;     u32div_t result;
-;;;     result.quot = dividend;
-					; euhl : result.quot
-
-	push	bc
-
-	ld	c, a			; c = A
-	ld	a, i			; a = I
-					; pf = IEF2
-	di
-
-	ld	a, c			; a = A
-	exx
-	pop	bc
-	ld	e, a			; eubc' : divisor
-
-	push	af
-
-;;;     result.rem = 0;
-	xor	a, a
-	sbc	hl, hl			; auhl' : result.rem
-
-;;;     int i = 32;
-	exx
-	ld	b, 32			; b : i
-
-;;;     do {
-.loop:
-
-;;;         bool dividendBit = result.quot >> 31;
-;;;         result.quot <<= 1;
-	add	hl, hl
-	rl	e
-;;;         result.rem = (result.rem << 1) + dividendBit;
-	exx
-	adc	hl, hl
-	adc	a, a
-
-;;;         bool quotBit = result.rem >= divisor;
-;;;         result.rem -= divisor;
-	sbc	hl, bc
-	sbc	a, e
-
-;;;         .if (!quotBit) {
-	jr	nc, .restore_skip
-;;;             result.rem += divisor;
-	add	hl, bc
-	adc	a, e
-;;;         }
-.restore_skip:
-
-;;;         .if (quotBit) {
-	exx
-	jr	c, .1_skip
-;;;             result.quot++;
-	inc	l
-;;;         }
-.1_skip:
-
-;;;     } while (--i != 0);
-	djnz	.loop
-
-;;;     return result;
-	pop	bc
-	bit	2, c
-	ret
-;;; }
-
-.else
 ; I: EUHL=dividend, AUBC=divisor
 ; O: auhl=EUHL%AUBC, euix=EUHL/AUBC, iyh=A, iyl=0
-	push	ix
-	push	iy
 
 	push	hl
 	pop	ix			; euix = dividend
@@ -97,7 +18,7 @@ __ldvrmu:
 
 	ld	iyl, 32
 
-.loop:
+.L.loop:
 	add	ix, ix
 	rl	e
 	adc	hl, hl
@@ -107,20 +28,13 @@ __ldvrmu:
 	sbc	a, iyh
 	inc	ixl
 
-	jr	nc, .restore_skip
+	jr	nc, .L.restore_skip
 	add	hl, bc
 	adc	a, iyh
 	dec	ixl
-.restore_skip:
+.L.restore_skip:
 
 	dec	iyl
-	jr	nz, .loop
+	jr	nz, .L.loop
 
-	lea	hl,ix+0
-
-	pop	iy
-	pop	ix
 	ret
-
-.endif
-

--- a/src/lib/libclang/lremu.src
+++ b/src/lib/libclang/lremu.src
@@ -3,12 +3,13 @@
 	.section	.text
 	.global	__lremu
 
+; REMEMBER to keep ldivu.src, lremu.src, and ldiv.src in sync with this choice
+.if 0
+
 __lremu:
 ; I: EUHL=dividend, AUBC=divisor
 ; O: euhl=EUHL%AUBC
-
-.if 1
-	call	__ldvrmu
+	call	__ldivu_lremu_common
 	ld	e, a
 	push	de
 	exx
@@ -19,7 +20,13 @@ __lremu:
 	ei
 	ret
 
+	.extern	__ldivu_lremu_common
+
 .else
+
+__lremu:
+; I: EUHL=dividend, AUBC=divisor
+; O: euhl=EUHL%AUBC
 	push	ix
 	push	iy
 
@@ -30,6 +37,7 @@ __lremu:
 	pop	iy
 	pop	ix
 	ret
-.endif
 
 	.extern	__ldvrmu
+
+.endif


### PR DESCRIPTION
Fixes some issues pointed out here https://github.com/AgonPlatform/agondev/pull/38#issuecomment-4216008561.

Adds fallback code for `ldiv_t ldiv(long, long)` that does not use shadow registers or interrupts.

Some label names/comments were changed, since I copied the code from this commit of the CE-toolchain https://github.com/CE-Programming/toolchain/tree/e967bf889a79558c22d99f256f8c27fc81fecafb

I also made it so `__ldvrmu` follows Zilog's calling conventions, with the `exx __ldvrmu` routine being renamed to `__ldivu_lremu_common` since it uses a completely different calling convention.
```
Zilog __ldvrmu:
; I: EUHL=dividend, AUBC=divisor
; O: a[uhl']=EUHL%AUBC, bcu=0, b=A, c=?, euhl=EUHL/AUBC, eubc'=AUBC, zf=!IEF2

exx __ldvrmu:
; I: EUHL=dividend, AUBC=divisor
; O: auhl=EUHL%AUBC, euix=EUHL/AUBC, iyh=A, iyl=0
```
